### PR TITLE
add submodule step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Building
 ========
 This library links against [`libJudy`](http://judy.sourceforge.net/), which must
 be installed before building this. It also depends on Cython. With those pieces 
-in place, it's business as usual
+in place, it's almost business as usual, after installing the C++ submodule
 
+	git submodule init
+	git submodule update
 	python setup.py install
 
 Usage


### PR DESCRIPTION
after pulling the code and trying to build simhash-py, i didn't realize that simhash-py needed the submodule to be added before building.

This is the README fix
