### PR TITLE
Fixed the hashes() function so it actually returns stored hashes, as …

### DIFF
--- a/simhash/table.pyx
+++ b/simhash/table.pyx
@@ -100,7 +100,7 @@ cdef class PyTable:
         cdef object results = list()
         cdef const_iterator_t it = self.tbl.begin()
         while it != self.tbl.end():
-            results.append(deref(it))
+            results.append(self.unpermute(deref(it)))
             preinc(it)
         return results
 


### PR DESCRIPTION
Table 0 isn't guaranteed to be in the original permutation (we only permute the first x elements, the remaining ones are just appended and can be in any order), so hashes() will return the permuted versions of the hashes, which isn't very useful. This will also let it pass test.py if you have the fixed iterator in simhash-cpp. 