### PR TITLE
Version bump to 0.2.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ ext_modules = [
 ]
 
 setup(name           = 'simhash',
-    version          = '0.2.0rc1',
+    version          = '0.2.0',
     description      = 'Near-Duplicate Detection with Simhash',
     url              = 'http://github.com/seomoz/simhash-py',
     author           = 'Dan Lecocq',


### PR DESCRIPTION
It would seem that `simhash>=0.2` doesn't accept `0.2.0rc1` as matching.

@b4hand @neilmb @lindseyreno 