### PR TITLE
[WIP] Add AppVeyor CI setup on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,11 +11,12 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda-x64
-    # not running the other tests at the moment
-    # (PY3 not yet supported)
-    #- PYTHON_VERSION: 3.5
-    #  PYTHON_ARCH: "64"
-    #  MINICONDA: C:\Miniconda3-x64
+    - PYTHON_VERSION: 3.4
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
+    - PYTHON_VERSION: 3.5
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda3-x64
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
@@ -30,10 +31,13 @@ install:
   - "conda create -n simhash-env --yes python=%PYTHON_VERSION%"
   - activate simhash-env
   - pip install -r requirements.txt
+  - git submodule update --init --recursive
   - python setup.py install
 
 
 
 test_script:
   - activate simhash-env # activate the virtualenv
-  - make test
+  - python setup.py build_ext --inplace
+  - SET PYTHONHASHSEED=0
+  - nosetests --verbose --nocapture

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,8 @@ install:
   - conda update -q conda
   - conda info -a
   - "cd C:\\projects\\simhash-py"
-  # create a conda virtual environement and install pywin32
-  # (otherwise we get a cython compilation error)
-  - "conda create -n simhash-env --yes pywin32 python=%PYTHON_VERSION%"
+  # create a conda virtual environement
+  - "conda create -n simhash-env --yes python=%PYTHON_VERSION%"
   - activate simhash-env
   - pip install -r requirements.txt
   - python setup.py install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+# Adapted from https://github.com/bsmurphy/PyKrige/blob/master/appveyor.yml
+build: false
+
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
+  matrix:
+    - PYTHON_VERSION: 2.7
+      PYTHON_ARCH: "64"
+      MINICONDA: C:\Miniconda-x64
+    # not running the other tests at the moment
+    # (PY3 not yet supported)
+    #- PYTHON_VERSION: 3.5
+    #  PYTHON_ARCH: "64"
+    #  MINICONDA: C:\Miniconda3-x64
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH% %MINICONDA%"
+
+install:
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - "cd C:\\projects\\simhash-py"
+  # create a conda virtual environement and install pywin32
+  # (otherwise we get a cython compilation error)
+  - "conda create -n simhash-env --yes pywin32 python=%PYTHON_VERSION%"
+  - activate simhash-env
+  - pip install -r requirements.txt
+  - python setup.py install
+
+
+
+test_script:
+  - activate simhash-env # activate the virtualenv
+  - make test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,13 +8,16 @@ environment:
     # See: http://stackoverflow.com/a/13751649/163740
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_compiler.cmd"
   matrix:
-    - PYTHON_VERSION: 2.7
-      PYTHON_ARCH: "64"
-      MINICONDA: C:\Miniconda-x64
-    - PYTHON_VERSION: 3.4
+   #- PYTHON_VERSION: 2.7
+   #- PYTHON_ARCH: "64"
+   #- MINICONDA: C:\Miniconda-x64
+   # - PYTHON_VERSION: 3.4
+   #   PYTHON_ARCH: "64"
+   #   MINICONDA: C:\Miniconda3-x64
+    - PYTHON_VERSION: 3.5
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
-    - PYTHON_VERSION: 3.5
+    - PYTHON_VERSION: 3.6
       PYTHON_ARCH: "64"
       MINICONDA: C:\Miniconda3-x64
 

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
 
+import os
+
 # Complain on 32-bit systems. See README for more details
 import struct
 if struct.calcsize('P') < 8:
@@ -15,40 +17,44 @@ if struct.calcsize('P') < 8:
         'Simhash-py does not work on 32-bit systems. See README.md')
 
 ext_files = [
-    'simhash/simhash-cpp/src/permutation.cpp',
-    'simhash/simhash-cpp/src/simhash.cpp'
+    os.path.join('simhash','simhash-cpp', 'src', 'permutation.cpp'),
+    os.path.join('simhash','simhash-cpp', 'src', 'simhash.cpp')
 ]
 
 kwargs = {}
 
+print(os.listdir(os.path.join("simhash", "simhash-cpp")))
+
 try:
     from Cython.Distutils import build_ext
+
+    # Adapt extra_compile_args based on the compiler used
+    # https://stackoverflow.com/a/5192738/1791279
+    class build_ext_subclass( build_ext ):
+        def build_extensions(self):
+            c = self.compiler.compiler_type
+            if c == "msvc":
+                pass  # C++ 11 support in Visual Studio should be turned on by default
+                      # and -std=c++11 is not a valid option
+            else:
+               for e in self.extensions:
+                   e.extra_compile_args = ['-std=c++11']
+            build_ext.build_extensions(self)
+
     print('Building from Cython')
-    ext_files.append('simhash/simhash.pyx')
-    kwargs['cmdclass'] = {'build_ext': build_ext}
+    ext_files.append(os.path.join('simhash', 'simhash.pyx'))
+    kwargs['cmdclass'] = {'build_ext': build_ext_subclass}
 except ImportError:
     print('Buidling from C++')
-    ext_files.append('simhash/simhash.cpp')
+    ext_files.append(os.path.join('simhash','simhash.cpp'))
 
 ext_modules = [
     Extension('simhash.simhash', ext_files,
         language='c++',
-        include_dirs=['simhash/simhash-cpp/include']
+        include_dirs=[os.path.join('simhash','simhash-cpp','include')]
     )
 ]
 
-# Adapt extra_compile_args based on the compiler used
-# https://stackoverflow.com/a/5192738/1791279
-class build_ext_subclass( build_ext ):
-    def build_extensions(self):
-        c = self.compiler.compiler_type
-        print(c)
-        if c == "msvc":
-            pass  # C++ 11 support in Visual Studio should be turned on by default
-        else:
-           for e in self.extensions:
-               e.extra_compile_args = ['-std=c++11']
-        build_ext.build_extensions(self)
 
 
 setup(name           = 'simhash',

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,6 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
 
-import os
-
-print(os.environ['CXX'])
-
 # Complain on 32-bit systems. See README for more details
 import struct
 if struct.calcsize('P') < 8:
@@ -37,10 +33,23 @@ except ImportError:
 ext_modules = [
     Extension('simhash.simhash', ext_files,
         language='c++',
-        extra_compile_args=['-std=c++11'],
         include_dirs=['simhash/simhash-cpp/include']
     )
 ]
+
+# Adapt extra_compile_args based on the compiler used
+# https://stackoverflow.com/a/5192738/1791279
+class build_ext_subclass( build_ext ):
+    def build_extensions(self):
+        c = self.compiler.compiler_type
+        print(c)
+        if c == "msvc":
+            pass  # C++ 11 support in Visual Studio should be turned on by default
+        else:
+           for e in self.extensions:
+               e.extra_compile_args = ['-std=c++11']
+        build_ext.build_extensions(self)
+
 
 setup(name           = 'simhash',
     version          = '0.2.0',

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 #! /usr/bin/env python
 from __future__ import print_function
 
-from distutils.core import setup
-from distutils.extension import Extension
+try:
+    from setuptools.core import setup
+    from setuptools.extension import Extension
+except ImportError:
+    from distutils.core import setup
+    from distutils.extension import Extension
+
+import os
+
+print(os.environ['CXX'])
 
 # Complain on 32-bit systems. See README for more details
 import struct


### PR DESCRIPTION
This PR aims to track progress on building simhash-py on Windows using the Microsoft Visual Studio compilers, as discussed in issue #29. It adds,

 * a `appveyor.yml` setup script (that would require to activate Appveyor CI on this repository)
 * makes paths in `setup.py` OS independent

This is still work in progress,  currently Windows [builds for all Python versions fail](https://ci.appveyor.com/project/rth/simhash-py) as discussed in the parent issue #29, in particular detailed error messages can be found for,
  * [ ] [PY2.7](https://ci.appveyor.com/project/rth/simhash-py/build/job/ruicxy03w302d03m) -> build fails
  * [ ] [PY3.4](https://ci.appveyor.com/project/rth/simhash-py/build/job/w2pxhj8vu032wyiq)-> build fails
  * [ ] [PY3.5](https://ci.appveyor.com/project/rth/simhash-py/build/job/agkax5k8n0ickimcp) -> build fails

**Notes**
  * this [SO post](https://stackoverflow.com/a/12970619/1791279) seems relevant, [msinttypes](https://code.google.com/archive/p/msinttypes/) could be a solution. 
