### PR TITLE
Create pypi release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[metadata]
+description-file = README.md
+
 [nosetests]
 verbosity=2
 rednose=1

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ ext_modules = [
 ]
 
 setup(
-    name='simhash',
-    version='0.3.0',
+    name='simhash-py',
+    version='0.4.0',
     description='Near-Duplicate Detection with Simhash',
     url='http://github.com/seomoz/simhash-py',
     author='Dan Lecocq',


### PR DESCRIPTION
This renames the distribution to be called simhash-py. This shouldn't affect any code because the package name once installed is still called simhash, so `import simhash` should still work. Also, I'm bumping the minor version just in case there are any unknown side effects.

This is in response to #36.