### PR TITLE
Added a few missing files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,8 @@
 include simhash/simhash.cpp
 include simhash/simhash-cpp/src/*
 include simhash/simhash-cpp/include/*
+include test/*
+makefile
+LICENSE
+README.md
+requirements.txt


### PR DESCRIPTION
The latest 0.4.0 release on PyPi has a few missing files in the .tar.gz such as README, LICENCE etc. 

This is probably not a big issue, but PR adds these missing files to `MANIFEST.in` so that they could be included in the following releases..